### PR TITLE
Improve handling of NZBGet behind reverse proxy

### DIFF
--- a/pynzbgetapi/__init__.py
+++ b/pynzbgetapi/__init__.py
@@ -35,7 +35,7 @@ class NZBGetAPI:
         ssl = "s" if secure else ""
 
         if username is not None and password is not None:
-            url = f"http{ssl}://{quote(username)}:{quote(password)}@{host}:{port}{urlbase}/xmlrpc"
+            url = f"http{ssl}://{host}:{port}/{quote(username)}:{quote(password)}{urlbase}/xmlrpc"
         else:
             url = f"http{ssl}://{host}:{port}{urlbase}/xmlrpc"
 

--- a/test_script.py
+++ b/test_script.py
@@ -3,24 +3,85 @@ import sys
 import argparse
 from pynzbgetapi import NZBGetAPI
 
-
 if __name__=="__main__":
-        
+
+    # Define script arguments
     parser = argparse.ArgumentParser(description='Call NZBGet APIs.')
-    parser.add_argument('host', help='the host')
-    parser.add_argument('-u', '--username', dest='username', action='store', required=False,
-                        help='the host')
-    parser.add_argument('-pw', '--password', dest='password', action='store', required=False,
-                        help='the host')                                                
+    parser.add_argument('host', help='the host', default='localhost')
+    parser.add_argument('-p', '--port', dest='port', type=int, action='store', required=False, default='6789', help='Set the correct port')
+    parser.add_argument('-u', '--username', dest='username', action='store', required=False, default="nzbget", help='a valid username')
+    parser.add_argument('-pw', '--password', dest='password', action='store', required=False, default="tegbzn6789", help='a valid password')
+    parser.add_argument('-s', '--secure', dest='secure', action='store', required=False, default=False, help='use True to set the connection to https, must specify the correct port to match')
+    parser.add_argument('-v', '--verify-certificate', dest='verify_certificate', action='store', required=False, default="False", help='set True to enforce certificate validation')
+
+    # Create connection
     args = parser.parse_args()
-    nzb_api = NZBGetAPI(args.host, port=6789, username=args.username, password=args.password, secure=False, verify_certificate=False)
+    nzb_api = NZBGetAPI(args.host, port=args.port, username=args.username, password=args.password, secure=args.secure, verify_certificate=args.verify_certificate)
 
-    print(nzb_api.version())
-    print(nzb_api.status())
-    
+    # Start Testing
+    # Get Version
+    print("\n\nGet Version")
+    try:
+        print(nzb_api.version())
+    except:
+        print("Error: Could not get version")
+        sys.exit(1)
+
+    # Get Status
+    print("\n\nGet Status")
+    try:
+        print(nzb_api.status())
+    except:
+        print("Error: Could not get status")
+        sys.exit(1)
+
+    # Get Queue
+    print("\n\nGet Queue")
+    try:
+        print(nzb_api.listgroups(number_of_log_entries='3'))
+    except:
+        print("Error: Could not get queue")
+        sys.exit(1)
+
+    # Limit Download & Reset
+    print("\n\nLimit Download Rate")
+    try:
+        print(nzb_api.rate(5000))
+    except:
+        print("Error: Could not limit download speed, check user permissions")
+        sys.exit(1)
+
+    print("\n\nReset Download Rate")
+    try:
+        print(nzb_api.rate(0))
+    except:
+        print("Error: Could not reset download speed, check user permissions")
+        sys.exit(1)
+
+    # Pause & Resume Downloads
+    print("\n\nPause Downloads")
+    try:
+        print(nzb_api.pausedownload())
+    except:
+        print("Error: Could not pause downloads, check user permissions")
+        sys.exit(1)
+
+    print("\n\nResume Downloads")
+    try:
+        print(nzb_api.resumedownload())
+    except:
+        print("Error: Could not resume downloads, check user permissions")
+        sys.exit(1)
+
+    # Get History
     res = nzb_api.history()
-    print(res)
 
-    print(res.scan())
-    print(res.status())
+    print("\n\nGet History")
+    try:
+        print(res)
+    except:
+        print("Error: Could not get history")
+        sys.exit(1)
 
+
+    print("\n\nTesting Passed")


### PR DESCRIPTION
This PR (based on Issue #3 ) improves compatibility for utilising the username and password handling behind reverse proxies and supports Home Assistant Users with using NZBGet.

In addition to improving the handling of connections as per the NZB API docs, I have added some basic tests to the test_script.py file to ensure the user has correct permissions and some basic information is pulled down.

@holiestofhandgrenades let me know if you are ok with this PR or if you have comments.